### PR TITLE
feat(podcasts): fixes description display on podcasts page

### DIFF
--- a/src/pages/Content/components/Podcast/Podcast.tsx
+++ b/src/pages/Content/components/Podcast/Podcast.tsx
@@ -22,7 +22,7 @@ export default function Podcast({ id, description }: PodcastProps) {
         <div data-testid="content" className="mx-auto">
           {description && (
             <div data-testid="podcast-description" className="mb-8">
-              description
+              {description}
             </div>
           )}
 


### PR DESCRIPTION
Apologies. Just realized while testing in dev env that the new description div needed a fix to display the actual content.